### PR TITLE
Fix typo from ffe34cf

### DIFF
--- a/gdb.py
+++ b/gdb.py
@@ -52,7 +52,7 @@ class DebugAdapterGdb(gdblike.DebugAdapterGdbLike):
 
 	def connect_continued(self, sock, rsp_connect):
 		self.sock = sock
-		self.rspConn = connection
+		self.rspConn = rsp_connect
 
 		self.reg_info_load()
 


### PR DESCRIPTION
Fixing variable name to avoid exception on use of undefined variable "connection".