### PR TITLE
Bare minimum Qt 6 compatibility fixups

### DIFF
--- a/dockwidgets/AdapterSettingsDialog.py
+++ b/dockwidgets/AdapterSettingsDialog.py
@@ -1,9 +1,15 @@
-from PySide2 import QtCore
-from PySide2.QtCore import Qt, QAbstractItemModel, QModelIndex, QSize
-from PySide2.QtGui import QPalette, QFontMetricsF
-from PySide2.QtWidgets import QApplication, QHBoxLayout, QVBoxLayout, QWidget, QDialog, QPushButton, QFormLayout, QLineEdit, QLabel, QMenu, QCheckBox
-
 import binaryninjaui
+if "qt_major_version" in binaryninjaui.__dict__ and binaryninjaui.qt_major_version == 6:
+	from PySide6 import QtCore
+	from PySide6.QtCore import Qt, QAbstractItemModel, QModelIndex, QSize
+	from PySide6.QtGui import QPalette, QFontMetricsF
+	from PySide6.QtWidgets import QApplication, QHBoxLayout, QVBoxLayout, QWidget, QDialog, QPushButton, QFormLayout, QLineEdit, QLabel, QMenu, QCheckBox
+else:
+	from PySide2 import QtCore
+	from PySide2.QtCore import Qt, QAbstractItemModel, QModelIndex, QSize
+	from PySide2.QtGui import QPalette, QFontMetricsF
+	from PySide2.QtWidgets import QApplication, QHBoxLayout, QVBoxLayout, QWidget, QDialog, QPushButton, QFormLayout, QLineEdit, QLabel, QMenu, QCheckBox
+
 from binaryninja import BinaryView, Settings, SettingsScope
 from binaryninjaui import DockContextHandler, UIActionHandler, LinearView, ViewFrame, UIContext
 

--- a/dockwidgets/BreakpointsWidget.py
+++ b/dockwidgets/BreakpointsWidget.py
@@ -1,9 +1,15 @@
-from PySide2 import QtCore
-from PySide2.QtCore import Qt, QAbstractItemModel, QModelIndex, QSize
-from PySide2.QtGui import QPalette, QFontMetricsF
-from PySide2.QtWidgets import QApplication, QHBoxLayout, QVBoxLayout, QWidget, QTableView, QItemDelegate, QStyle, QHeaderView, QAbstractItemView
-
 import binaryninjaui
+if "qt_major_version" in binaryninjaui.__dict__ and binaryninjaui.qt_major_version == 6:
+	from PySide6 import QtCore
+	from PySide6.QtCore import Qt, QAbstractItemModel, QModelIndex, QSize
+	from PySide6.QtGui import QPalette, QFontMetricsF
+	from PySide6.QtWidgets import QApplication, QHBoxLayout, QVBoxLayout, QWidget, QTableView, QItemDelegate, QStyle, QHeaderView, QAbstractItemView
+else:
+	from PySide2 import QtCore
+	from PySide2.QtCore import Qt, QAbstractItemModel, QModelIndex, QSize
+	from PySide2.QtGui import QPalette, QFontMetricsF
+	from PySide2.QtWidgets import QApplication, QHBoxLayout, QVBoxLayout, QWidget, QTableView, QItemDelegate, QStyle, QHeaderView, QAbstractItemView
+
 from binaryninjaui import DockContextHandler, UIActionHandler, ThemeColor
 from binaryninja import BinaryView
 
@@ -169,9 +175,6 @@ class DebugBreakpointsWidget(QWidget, DockContextHandler):
 
 		self.table.resizeColumnsToContents()
 		self.table.resizeRowsToContents()
-
-		for i in range(len(self.model.columns)):
-			self.table.setColumnWidth(i, self.item_delegate.sizeHint(self.table.viewOptions(), self.model.index(-1, i, QModelIndex())).width())
 		self.table.horizontalHeader().setSectionResizeMode(1, QHeaderView.Stretch)
 
 		layout = QVBoxLayout()

--- a/dockwidgets/ConsoleWidget.py
+++ b/dockwidgets/ConsoleWidget.py
@@ -1,7 +1,15 @@
-from PySide2 import QtCore
-from PySide2.QtCore import Qt, QSize
-from PySide2.QtWidgets import QApplication, QHBoxLayout, QVBoxLayout, QLabel, QWidget, QPushButton, QLineEdit, QTextEdit
-from PySide2.QtGui import QTextCursor
+import binaryninjaui
+if "qt_major_version" in binaryninjaui.__dict__ and binaryninjaui.qt_major_version == 6:
+	from PySide6 import QtCore
+	from PySide6.QtCore import Qt, QSize
+	from PySide6.QtWidgets import QApplication, QHBoxLayout, QVBoxLayout, QLabel, QWidget, QPushButton, QLineEdit, QTextEdit
+	from PySide6.QtGui import QTextCursor
+else:
+	from PySide2 import QtCore
+	from PySide2.QtCore import Qt, QSize
+	from PySide2.QtWidgets import QApplication, QHBoxLayout, QVBoxLayout, QLabel, QWidget, QPushButton, QLineEdit, QTextEdit
+	from PySide2.QtGui import QTextCursor
+
 import binaryninja
 from binaryninjaui import DockHandler, DockContextHandler, UIActionHandler, getMonospaceFont
 

--- a/dockwidgets/ControlsWidget.py
+++ b/dockwidgets/ControlsWidget.py
@@ -1,6 +1,14 @@
-from PySide2 import QtCore, QtGui
-from PySide2.QtCore import Qt
-from PySide2.QtWidgets import QApplication, QHBoxLayout, QVBoxLayout, QLabel, QWidget, QPushButton, QLineEdit, QToolBar, QToolButton, QMenu, QAction
+import binaryninjaui
+if "qt_major_version" in binaryninjaui.__dict__ and binaryninjaui.qt_major_version == 6:
+	from PySide6 import QtCore, QtGui
+	from PySide6.QtCore import Qt
+	from PySide6.QtGui import QAction
+	from PySide6.QtWidgets import QApplication, QHBoxLayout, QVBoxLayout, QLabel, QWidget, QPushButton, QLineEdit, QToolBar, QToolButton, QMenu
+else:
+	from PySide2 import QtCore, QtGui
+	from PySide2.QtCore import Qt
+	from PySide2.QtWidgets import QApplication, QHBoxLayout, QVBoxLayout, QLabel, QWidget, QPushButton, QLineEdit, QToolBar, QToolButton, QMenu, QAction
+
 from binaryninja import execute_on_main_thread_and_wait, BinaryView
 from binaryninja.interaction import show_message_box, MessageBoxIcon, MessageBoxButtonSet, MessageBoxButtonResult
 from binaryninjaui import ViewFrame

--- a/dockwidgets/DebugView.py
+++ b/dockwidgets/DebugView.py
@@ -1,12 +1,18 @@
-from PySide2 import QtCore
-from PySide2.QtCore import Qt, QAbstractItemModel, QModelIndex, QSize, QTimer
-from PySide2.QtGui import QPalette, QFontMetricsF
-from PySide2.QtWidgets import QApplication, QHBoxLayout, QVBoxLayout, QWidget, QStyle, QSplitter, QLabel
+import binaryninjaui
+if "qt_major_version" in binaryninjaui.__dict__ and binaryninjaui.qt_major_version == 6:
+	from PySide6 import QtCore
+	from PySide6.QtCore import Qt, QAbstractItemModel, QModelIndex, QSize, QTimer
+	from PySide6.QtGui import QPalette, QFontMetricsF
+	from PySide6.QtWidgets import QApplication, QHBoxLayout, QVBoxLayout, QWidget, QStyle, QSplitter, QLabel
+else:
+	from PySide2 import QtCore
+	from PySide2.QtCore import Qt, QAbstractItemModel, QModelIndex, QSize, QTimer
+	from PySide2.QtGui import QPalette, QFontMetricsF
+	from PySide2.QtWidgets import QApplication, QHBoxLayout, QVBoxLayout, QWidget, QStyle, QSplitter, QLabel
 
 import re
 import threading
 
-import binaryninjaui
 from binaryninja import BinaryView, PythonScriptingInstance, InstructionTextToken, InstructionTextTokenType, DisassemblyTextLine, LinearDisassemblyLine, LinearDisassemblyLineType, HighlightStandardColor, core_version
 from binaryninja.enums import InstructionTextTokenType
 from binaryninjaui import View, ViewType, UIAction, UIActionHandler, LinearView, DisassemblyContainer, ViewFrame, DockHandler, TokenizedTextView, HistoryEntry

--- a/dockwidgets/ModulesWidget.py
+++ b/dockwidgets/ModulesWidget.py
@@ -1,10 +1,16 @@
-from PySide2 import QtCore
-from PySide2.QtCore import Qt, QAbstractItemModel, QModelIndex, QSize
-from PySide2.QtGui import QPalette, QFontMetricsF
-from PySide2.QtWidgets import QApplication, QHBoxLayout, QVBoxLayout, QWidget, QTableView, QItemDelegate, QStyle, QHeaderView, QAbstractItemView, QLabel, QPushButton
+import binaryninjaui
+if "qt_major_version" in binaryninjaui.__dict__ and binaryninjaui.qt_major_version == 6:
+	from PySide6 import QtCore
+	from PySide6.QtCore import Qt, QAbstractItemModel, QModelIndex, QSize
+	from PySide6.QtGui import QPalette, QFontMetricsF
+	from PySide6.QtWidgets import QApplication, QHBoxLayout, QVBoxLayout, QWidget, QTableView, QItemDelegate, QStyle, QHeaderView, QAbstractItemView, QLabel, QPushButton
+else:
+	from PySide2 import QtCore
+	from PySide2.QtCore import Qt, QAbstractItemModel, QModelIndex, QSize
+	from PySide2.QtGui import QPalette, QFontMetricsF
+	from PySide2.QtWidgets import QApplication, QHBoxLayout, QVBoxLayout, QWidget, QTableView, QItemDelegate, QStyle, QHeaderView, QAbstractItemView, QLabel, QPushButton
 
 import binaryninja
-import binaryninjaui
 from binaryninjaui import DockContextHandler, UIActionHandler, ThemeColor
 
 from . import widget
@@ -144,9 +150,6 @@ class DebugModulesWidget(QWidget, DockContextHandler):
 
 		self.table.resizeColumnsToContents()
 		self.table.resizeRowsToContents()
-
-		for i in range(len(self.model.columns)):
-			self.table.setColumnWidth(i, self.item_delegate.sizeHint(self.table.viewOptions(), self.model.index(-1, i, QModelIndex())).width())
 
 		update_layout = QHBoxLayout()
 		update_layout.setContentsMargins(0, 0, 0, 0)

--- a/dockwidgets/RegistersWidget.py
+++ b/dockwidgets/RegistersWidget.py
@@ -1,9 +1,15 @@
-from PySide2 import QtCore
-from PySide2.QtCore import Qt, QAbstractItemModel, QModelIndex, QSize
-from PySide2.QtGui import QPalette, QFontMetricsF
-from PySide2.QtWidgets import QApplication, QHBoxLayout, QVBoxLayout, QWidget, QTableView, QItemDelegate, QStyle, QHeaderView, QAbstractItemView
-
 import binaryninjaui
+if "qt_major_version" in binaryninjaui.__dict__ and binaryninjaui.qt_major_version == 6:
+	from PySide6 import QtCore
+	from PySide6.QtCore import Qt, QAbstractItemModel, QModelIndex, QSize
+	from PySide6.QtGui import QPalette, QFontMetricsF
+	from PySide6.QtWidgets import QApplication, QHBoxLayout, QVBoxLayout, QWidget, QTableView, QItemDelegate, QStyle, QHeaderView, QAbstractItemView
+else:
+	from PySide2 import QtCore
+	from PySide2.QtCore import Qt, QAbstractItemModel, QModelIndex, QSize
+	from PySide2.QtGui import QPalette, QFontMetricsF
+	from PySide2.QtWidgets import QApplication, QHBoxLayout, QVBoxLayout, QWidget, QTableView, QItemDelegate, QStyle, QHeaderView, QAbstractItemView
+
 from binaryninjaui import DockContextHandler, UIActionHandler, ThemeColor
 from binaryninja import BinaryView
 
@@ -206,9 +212,6 @@ class DebugRegistersWidget(QWidget, DockContextHandler):
 
 		self.table.resizeColumnsToContents()
 		self.table.resizeRowsToContents()
-
-		for i in range(len(self.model.columns)):
-			self.table.setColumnWidth(i, self.item_delegate.sizeHint(self.table.viewOptions(), self.model.index(-1, i, QModelIndex())).width())
 
 		layout = QVBoxLayout()
 		layout.setContentsMargins(0, 0, 0, 0)

--- a/dockwidgets/StackWidget.py
+++ b/dockwidgets/StackWidget.py
@@ -1,10 +1,16 @@
-from PySide2 import QtCore
-from PySide2.QtCore import Qt, QAbstractItemModel, QModelIndex, QSize
-from PySide2.QtGui import QPalette, QFontMetricsF
-from PySide2.QtWidgets import QApplication, QHBoxLayout, QVBoxLayout, QWidget, QTableView, QItemDelegate, QStyle, QHeaderView, QAbstractItemView
+import binaryninjaui
+if "qt_major_version" in binaryninjaui.__dict__ and binaryninjaui.qt_major_version == 6:
+	from PySide6 import QtCore
+	from PySide6.QtCore import Qt, QAbstractItemModel, QModelIndex, QSize
+	from PySide6.QtGui import QPalette, QFontMetricsF
+	from PySide6.QtWidgets import QApplication, QHBoxLayout, QVBoxLayout, QWidget, QTableView, QItemDelegate, QStyle, QHeaderView, QAbstractItemView
+else:
+	from PySide2 import QtCore
+	from PySide2.QtCore import Qt, QAbstractItemModel, QModelIndex, QSize
+	from PySide2.QtGui import QPalette, QFontMetricsF
+	from PySide2.QtWidgets import QApplication, QHBoxLayout, QVBoxLayout, QWidget, QTableView, QItemDelegate, QStyle, QHeaderView, QAbstractItemView
 
 from binaryninja import Endianness, BinaryView
-import binaryninjaui
 from binaryninjaui import DockContextHandler, UIActionHandler, ThemeColor
 
 from . import widget
@@ -225,9 +231,6 @@ class DebugStackWidget(QWidget, DockContextHandler):
 
 		self.table.resizeColumnsToContents()
 		self.table.resizeRowsToContents()
-
-		for i in range(len(self.model.columns)):
-			self.table.setColumnWidth(i, self.item_delegate.sizeHint(self.table.viewOptions(), self.model.index(-1, i, QModelIndex())).width())
 
 		layout = QVBoxLayout()
 		layout.setContentsMargins(0, 0, 0, 0)

--- a/dockwidgets/ThreadsWidget.py
+++ b/dockwidgets/ThreadsWidget.py
@@ -1,9 +1,15 @@
-from PySide2 import QtCore
-from PySide2.QtCore import Qt, QAbstractItemModel, QModelIndex, QSize
-from PySide2.QtGui import QPalette, QFontMetricsF
-from PySide2.QtWidgets import QApplication, QHBoxLayout, QVBoxLayout, QWidget, QTableView, QItemDelegate, QStyle, QHeaderView, QAbstractItemView
-
 import binaryninjaui
+if "qt_major_version" in binaryninjaui.__dict__ and binaryninjaui.qt_major_version == 6:
+	from PySide6 import QtCore
+	from PySide6.QtCore import Qt, QAbstractItemModel, QModelIndex, QSize
+	from PySide6.QtGui import QPalette, QFontMetricsF
+	from PySide6.QtWidgets import QApplication, QHBoxLayout, QVBoxLayout, QWidget, QTableView, QItemDelegate, QStyle, QHeaderView, QAbstractItemView
+else:
+	from PySide2 import QtCore
+	from PySide2.QtCore import Qt, QAbstractItemModel, QModelIndex, QSize
+	from PySide2.QtGui import QPalette, QFontMetricsF
+	from PySide2.QtWidgets import QApplication, QHBoxLayout, QVBoxLayout, QWidget, QTableView, QItemDelegate, QStyle, QHeaderView, QAbstractItemView
+
 from binaryninja import BinaryView
 from binaryninjaui import DockContextHandler, UIActionHandler, ThemeColor
 
@@ -191,9 +197,6 @@ class DebugThreadsWidget(QWidget, DockContextHandler):
 
 		self.table.resizeColumnsToContents()
 		self.table.resizeRowsToContents()
-
-		for i in range(len(self.model.columns)):
-			self.table.setColumnWidth(i, self.item_delegate.sizeHint(self.table.viewOptions(), self.model.index(-1, i, QModelIndex())).width())
 		self.table.horizontalHeader().setSectionResizeMode(1, QHeaderView.Stretch)
 
 		layout = QVBoxLayout()

--- a/dockwidgets/widget.py
+++ b/dockwidgets/widget.py
@@ -1,4 +1,9 @@
-from PySide2.QtWidgets import QApplication, QWidget
+import binaryninjaui
+if "qt_major_version" in binaryninjaui.__dict__ and binaryninjaui.qt_major_version == 6:
+	from PySide6.QtWidgets import QApplication, QWidget
+else:
+	from PySide2.QtWidgets import QApplication, QWidget
+
 from binaryninjaui import DockHandler
 import sys
 import traceback

--- a/ui.py
+++ b/ui.py
@@ -1,7 +1,15 @@
-from PySide2 import QtCore
-from PySide2.QtCore import Qt
-from PySide2.QtWidgets import QApplication, QHBoxLayout, QVBoxLayout, QLabel, QWidget, QPushButton, QLineEdit
-from PySide2.QtGui import QDesktopServices
+import binaryninjaui
+if "qt_major_version" in binaryninjaui.__dict__ and binaryninjaui.qt_major_version == 6:
+	from PySide6 import QtCore
+	from PySide6.QtCore import Qt
+	from PySide6.QtWidgets import QApplication, QHBoxLayout, QVBoxLayout, QLabel, QWidget, QPushButton, QLineEdit
+	from PySide6.QtGui import QDesktopServices
+else:
+	from PySide2 import QtCore
+	from PySide2.QtCore import Qt
+	from PySide2.QtWidgets import QApplication, QHBoxLayout, QVBoxLayout, QLabel, QWidget, QPushButton, QLineEdit
+	from PySide2.QtGui import QDesktopServices
+
 from binaryninja.plugin import PluginCommand
 from binaryninja import Endianness, HighlightStandardColor, execute_on_main_thread, execute_on_main_thread_and_wait, LowLevelILOperation, BinaryReader
 from binaryninja.settings import Settings


### PR DESCRIPTION
- Imports have been adjusted as needed for `PySide6`
- Table column size hint configuration has been removed as it depended on the now-missing `viewOptions()` function, which didn't work in the first place, so no harm done