### PR TITLE
Fix documentation path.

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -612,7 +612,7 @@ def valid_control_step_return(bv):
 #------------------------------------------------------------------------------
 
 def helpDocs(context):
-	docPath = os.path.join(os.path.dirname(__file__), "Documentation")
+	docPath = os.path.join(os.path.dirname(__file__), "documentation")
 	URLPath = pathlib.Path(os.path.join(docPath, "Manual.html")).as_uri()
 	QDesktopServices.openUrl(URLPath)
 


### PR DESCRIPTION
The menu item *User Documentation* tries to access the documentation folder using the title-cased pathname, which does not work on *nix-like operating systems as the folder is all lower-case.